### PR TITLE
Enables route scoped dependency injection

### DIFF
--- a/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/generator/ktorserver/KtorRouteGenerator.kt
+++ b/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/generator/ktorserver/KtorRouteGenerator.kt
@@ -29,7 +29,6 @@ class KtorRouteGenerator(
             .addImport("io.ktor.http", "HttpStatusCode", "ContentType")
             .addImport(context.packageName, context.className)
             .addFunction(installFunction(installFunction, controllers))
-            .addFunction(serviceLocatorGet(serviceLocatorClass))
             .addType(serviceLocatorInterface())
             .build()
             .writeTo(outputDirectory)
@@ -68,7 +67,7 @@ class KtorRouteGenerator(
     private fun CodeBlock.Builder.generateCall(controller: KtorController) {
         val poet = PoetController(basePackage, controller)
         addStatement("val context = ${context.className}.${context.factoryName}(call)")
-        addStatement("val controller = locator.get<%T>()", poet.controllerClassName)
+        addStatement("val controller = with(locator) { getService(%T::class) }", poet.controllerClassName)
 
         val inputs = mutableListOf<String>()
         controller.request.pathParameters.forEach { (name, type) ->
@@ -164,22 +163,12 @@ private fun CodeBlock.Builder.generateBinaryResponse(response: KtorController.Re
     }
 }
 
-private fun serviceLocatorGet(serviceLocatorClass: ClassName): FunSpec {
-    val t = TypeVariableName("T", Any::class).copy(reified = true)
-    return FunSpec.builder("get")
-        .receiver(serviceLocatorClass)
-        .addModifiers(KModifier.PRIVATE, KModifier.INLINE)
-        .addTypeVariable(t)
-        .addCode("return this.getService(T::class)")
-        .returns(t)
-        .build()
-}
-
 private fun serviceLocatorInterface(): TypeSpec {
     val t = TypeVariableName("T", Any::class)
     return TypeSpec.interfaceBuilder("ServiceLocator")
         .addFunction(
             FunSpec.builder("getService")
+                .receiver(RoutingContext::class)
                 .addModifiers(KModifier.ABSTRACT)
                 .addTypeVariable(t)
                 .addParameter("type", KClass::class.asClassName().parameterizedBy(t))

--- a/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/parser/json/JsonFileParser.kt
+++ b/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/parser/json/JsonFileParser.kt
@@ -215,14 +215,12 @@ class JsonFileParser(private val handler: FileHandler) {
     }
 
     private fun parseMap(schema: JsonSchema, objectName: String): BaseJsonSpec {
-
         val properties = schema.additionalProperties!!
         val valueType = parse(properties, objectName)
 
         // Parse and validate map keys
         // The keys can only be string (default fallback) or an enum type
         val keyType: BaseJsonSpec? = when {
-
             schema.enum != null -> {
                 EnumJsonType(
                     null,
@@ -241,7 +239,6 @@ class JsonFileParser(private val handler: FileHandler) {
 
             schema.ref != null -> {
                 when (val result = parseRef(schema)) {
-
                     is DefJsonSpec -> {
                         val defined = definitions[result.def]
                         requireNotNull(defined) { "Cannot find sealed definition ${result.smartToString()}" }

--- a/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/plugin/server/ApplyGenerateKtorServer.kt
+++ b/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/plugin/server/ApplyGenerateKtorServer.kt
@@ -33,7 +33,7 @@ fun applyGenerateKtorServer(target: Project) {
             else -> inputName
         }
 
-        val output = target.layout.buildDirectory.dir("generated/sources/ktorServer/${folderName}/")
+        val output = target.layout.buildDirectory.dir("generated/sources/ktorServer/$folderName/")
         ktorServerInput.outputFolder.convention(output)
         ktorServerInput.transformerSpec.endpointTransformer.convention(DefaultEndpointTransformer::class.java)
         ktorServerInput.transformerSpec.ktorMapper.convention(DefaultKtorControllerMapper::class.java)

--- a/sample/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/sample/MockServices.kt
+++ b/sample/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/sample/MockServices.kt
@@ -3,6 +3,7 @@ package com.diconium.mobile.tools.kebabkrafter.sample
 import com.diconium.mobile.tools.kebabkrafter.sample.gen.petstore.ServiceLocator
 import com.diconium.mobile.tools.kebabkrafter.sample.gen.petstore.controllers.v1.GetPet
 import com.diconium.mobile.tools.kebabkrafter.sample.mock.v1.MockGetPetController
+import io.ktor.server.routing.*
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module
 import kotlin.reflect.KClass
@@ -15,5 +16,5 @@ object MockServices : ServiceLocator {
 
     private val koin = koinApplication { modules(controllers) }.koin
 
-    override fun <T : Any> getService(type: KClass<T>): T = koin.get(type)
+    override fun <T : Any> RoutingContext.getService(type: KClass<T>): T = koin.get(type)
 }

--- a/sample/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/sample/RealServices.kt
+++ b/sample/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/sample/RealServices.kt
@@ -1,14 +1,10 @@
 package com.diconium.mobile.tools.kebabkrafter.sample
 
-import com.diconium.mobile.tools.kebabkrafter.sample.controllers.v1.DeletePetIdController
-import com.diconium.mobile.tools.kebabkrafter.sample.controllers.v1.GetPetController
-import com.diconium.mobile.tools.kebabkrafter.sample.controllers.v1.GetPetIdController
-import com.diconium.mobile.tools.kebabkrafter.sample.controllers.v1.GetPetIdPdfController
-import com.diconium.mobile.tools.kebabkrafter.sample.controllers.v1.GetPetIdPhotoController
-import com.diconium.mobile.tools.kebabkrafter.sample.controllers.v1.PostPetController
+import com.diconium.mobile.tools.kebabkrafter.sample.controllers.v1.*
 import com.diconium.mobile.tools.kebabkrafter.sample.db.Database
 import com.diconium.mobile.tools.kebabkrafter.sample.gen.petstore.ServiceLocator
 import com.diconium.mobile.tools.kebabkrafter.sample.gen.petstore.controllers.v1.*
+import io.ktor.server.routing.*
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module
 import kotlin.reflect.KClass
@@ -25,6 +21,5 @@ object RealServices : ServiceLocator {
     }
 
     private val koin = koinApplication { modules(controllers) }.koin
-
-    override fun <T : Any> getService(type: KClass<T>): T = koin.get(type)
+    override fun <T : Any> RoutingContext.getService(type: KClass<T>): T = koin.get(type)
 }


### PR DESCRIPTION
Adds ktor 'RoutingContext' to the service locator 'getService' This enables dependency injection (such as Koin) to scope services to the call.

Also simplifies 'getService' from install routes by removing the inlined class. And applied ktlintFormat to the whole project